### PR TITLE
Add ability to download graph in SVG format.

### DIFF
--- a/src/app/modules/abstract/AbstractModule.js
+++ b/src/app/modules/abstract/AbstractModule.js
@@ -7,7 +7,8 @@ import OptionsPanel from './panels/options/OptionsPanel.js';
 export const DEFAULT_GRAPH_EXPORTERS = [];
 export const DEFAULT_IMAGE_EXPORTERS = [
   new GraphImageExporter('png'),
-  new GraphImageExporter('jpg')
+  new GraphImageExporter('jpg'),
+  new GraphImageExporter('svg')
 ];
 //TODO: This is inserted by Drawer.js, not used here. (which is weird)
 export const DEFAULT_PANELS = [ExportingPanel, OptionsPanel];

--- a/src/app/modules/abstract/exporter/GraphImageExporter.js
+++ b/src/app/modules/abstract/exporter/GraphImageExporter.js
@@ -2,7 +2,8 @@ import AbstractGraphExporter from './AbstractGraphExporter.js';
 
 import PNGIcon from 'icons/flat/PNGIcon.js';
 import JPGIcon from 'icons/flat/JPGIcon.js';
-import { downloadSVG } from 'util/Downloader.js';
+import XMLIcon from 'icons/flat/XMLIcon.js';
+import { downloadSVG, downloadImageFromSVG } from 'util/Downloader.js';
 
 class GraphImageExporter extends AbstractGraphExporter
 {
@@ -21,7 +22,11 @@ class GraphImageExporter extends AbstractGraphExporter
     const height = workspaceDim.height;
     const svg = workspace.getSVGForExport(width, height);
 
-    downloadSVG(filename, this._imageType, svg, width, height);
+    if (this._imageType === 'svg') {
+      downloadSVG(filename, svg);
+    } else {
+      downloadImageFromSVG(filename, this._imageType, svg, width, height);
+    }
   }
 
   //Override
@@ -43,6 +48,7 @@ class GraphImageExporter extends AbstractGraphExporter
     {
       case 'png': return I18N.toString("file.export.png.hint");
       case 'jpg': return I18N.toString("file.export.jpg.hint");
+      case 'svg': return "Export diagram as .svg"
       default: return super.getTitle();
     }
   }
@@ -54,6 +60,7 @@ class GraphImageExporter extends AbstractGraphExporter
     {
       case 'png': return I18N.toString("file.export.png");
       case 'jpg': return I18N.toString("file.export.jpg");
+      case 'svg': return "Export diagram as SVG";
       default: return super.getLabel();
     }
   }
@@ -71,6 +78,7 @@ class GraphImageExporter extends AbstractGraphExporter
     {
       case 'png': return PNGIcon;
       case 'jpg': return JPGIcon;
+      case 'svg': return XMLIcon;
       default: return null;
     }
   }

--- a/src/app/util/Downloader.js
+++ b/src/app/util/Downloader.js
@@ -6,11 +6,27 @@ export function downloadText(filename, textData)
   downloadURL(filename, getTextDataURI(textData));
 }
 
-export function downloadSVG(filename, filetype, svg, width, height)
+function createBlobFromSVG(svg)
 {
   const serializer = new XMLSerializer();
   const svgString = serializer.serializeToString(svg);
   const blob = new Blob([svgString], {type:'image/svg+xml'});
+  return blob
+}
+
+export function downloadSVG(filename, svg)
+{
+  const blob = createBlobFromSVG(svg);
+  const reader = new FileReader();
+  reader.onload = () => {
+    downloadURL(filename + ".svg", reader.result);
+  }
+  reader.readAsDataURL(blob);
+}
+
+export function downloadImageFromSVG(filename, filetype, svg, width, height)
+{
+  const blob = createBlobFromSVG(svg);
   const url = URL.createObjectURL(blob);
 
   const canvas = document.createElement('canvas');


### PR DESCRIPTION
This change adds a download button in the export tab for downloading the
graph as an SVG image.

Hi, I was using flapJS for homework and noticed that the PNG export was quite low resolution. Instead of allowing adjusting resolution on image exports, I added the ability to download the image as an SVG, allowing the end user to infinite scale. 

One issue is that I didn't know how to properly use internationalization (see GraphImageExporter.js).

Hope this helps.